### PR TITLE
fix: Remote end closed connection without response. Increase retry and update timeout

### DIFF
--- a/core/youtube/youtube_api.py
+++ b/core/youtube/youtube_api.py
@@ -52,7 +52,7 @@ def upload_video(
     print(f"Starting upload of file: {file_path} (Size: {file_size} bytes)")
 
     # Maximum retry attempts for upload
-    max_retries = 2
+    max_retries = 5  # increased retries to handle intermittent connection closures
     retry_count = 0
 
     while retry_count < max_retries:
@@ -93,18 +93,19 @@ def upload_video(
                 print("Retrying upload...")
                 # Sleep before retry to avoid rate limits
                 time.sleep(5)
+                continue
             else:
                 print(f"❌ Upload failed after {max_retries} attempts: {str(e)}")
                 raise e
         except Exception as e:
-            print(f"❌ Unexpected error during upload: {str(e)}")
-            # Retry socket timeout and other transient errors
-            if isinstance(e, (socket.timeout, TimeoutError)) and retry_count < max_retries:
-                retry_count += 1
+            retry_count += 1
+            if retry_count < max_retries:
                 print(f"⚠️ Upload error ({retry_count}/{max_retries}): {str(e)}, retrying...")
                 time.sleep(5)
                 continue
-            raise e
+            else:
+                print(f"❌ Upload failed after {max_retries} attempts: {str(e)}")
+                raise e
 
 
 def add_to_playlist(youtube: Resource, video_id: str, category: str) -> None:


### PR DESCRIPTION
This pull request makes improvements to the `upload_video` function in `core/youtube/youtube_api.py` to enhance error handling and robustness during video uploads. The changes include **increasing retry attempts for intermittent connection issues and refining the retry logic to ensure better handling of transient errors**.

### Enhancements to error handling and retry logic:
* Increased the maximum retry attempts from 2 to 5 to better handle intermittent connection closures during video uploads. (`core/youtube/youtube_api.py`, [core/youtube/youtube_api.pyL55-R55](diffhunk://#diff-916cfbe09b993f4d7cb6e04e034346c6c5b9ede8e6b0b1c03236e53654d63da9L55-R55))
* Refined the retry logic:
  - Added a `continue` statement after sleeping to avoid rate limits, ensuring the retry loop progresses correctly. (`core/youtube/youtube_api.py`, [core/youtube/youtube_api.pyR96-R107](diffhunk://#diff-916cfbe09b993f4d7cb6e04e034346c6c5b9ede8e6b0b1c03236e53654d63da9R96-R107))
  - Simplified error handling by removing specific transient error checks (e.g., `socket.timeout`) and relying on a general retry mechanism for all exceptions, improving maintainability. (`core/youtube/youtube_api.py`, [core/youtube/youtube_api.pyR96-R107](diffhunk://#diff-916cfbe09b993f4d7cb6e04e034346c6c5b9ede8e6b0b1c03236e53654d63da9R96-R107))
  - Added a fallback to raise an error after exhausting all retry attempts, ensuring proper failure reporting. (`core/youtube/youtube_api.py`, [core/youtube/youtube_api.pyR96-R107](diffhunk://#diff-916cfbe09b993f4d7cb6e04e034346c6c5b9ede8e6b0b1c03236e53654d63da9R96-R107))